### PR TITLE
appveyor: fix Go install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,12 @@ environment:
   nodejs_version: "20"
   matrix:
     - QT: C:\Qt\5.15.2\msvc2019_64
-      GOROOT: C:\go
+      # As installed by `choco`
+      GOROOT: C:\Program Files\Go
       GOPATH: C:\gopath\
       GOTOOLCHAIN: local
       PLATFORM: amd64
       COMPILER: msvc
-# https://www.appveyor.com/docs/windows-images-software/#golang
-# If you change this, also change the GOROOT variable above to point to the right installation folder.
-stack: go 1.22
 
 install:
   - ps: Install-Product node $env:nodejs_version
@@ -26,6 +24,9 @@ before_build:
 
 build_script:
   - echo on
+  - choco install go --version=1.22.6
+  - go version
+  - go env
   - choco install make
   - choco install nsis -pre
   - mkdir %GOPATH%\src\github.com\BitBoxSwiss


### PR DESCRIPTION
https://www.appveyor.com/docs/windows-images-software/#golang lists

> Go 1.22.1 x64 (C:\go - default in PATH)

But the image or docs are buggy, C:\go is a symlink of C:\go121 and Go 1.22 does not seem to exist.

We switch to choco to install the desired Go version. The benefit is that choco receives new updates faster too and has more granular version control.